### PR TITLE
fix(projects): decrease separator line thickness inside projects card

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
On the Projects page, the horizontal separator line within each projects card was too thick(3px) and did not match the figma design. I changed the border within the projects card to 1px to match the design.