### PR TITLE
fix(issues): change text color of page info below issues list

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
Change page/info pagination element (Page 1 of #) text color to a darker grey on issues page.